### PR TITLE
Bug fix: connection to a device of an unknown type fails

### DIFF
--- a/neatle/src/main/java/si/inova/neatle/CommandResult.java
+++ b/neatle/src/main/java/si/inova/neatle/CommandResult.java
@@ -107,4 +107,8 @@ public class CommandResult {
     public int getValueAsInt8() {
         return ByteBuffer.wrap(data).get(0);
     }
+
+    public int getValueAsInt32() {
+        return ByteBuffer.wrap(data).getInt();
+    }
 }

--- a/neatle/src/main/java/si/inova/neatle/Connection.java
+++ b/neatle/src/main/java/si/inova/neatle/Connection.java
@@ -84,7 +84,7 @@ public interface Connection {
      * so use {@link Neatle#createSubscription(android.content.Context, BluetoothDevice, UUID, UUID)}
      *
      * @param characteristicsUUID the UUUID of the desired characteristics
-     * @param listener the listener to add
+     * @param listener            the listener to add
      */
     void addCharacteristicsChangedListener(UUID characteristicsUUID, CharacteristicsChangedListener listener);
 
@@ -92,7 +92,7 @@ public interface Connection {
      * Removes the change listener privously added by {@link #addCharacteristicsChangedListener}
      *
      * @param characteristicsUUID characteristics UUID
-     * @param listener the listener to remove
+     * @param listener            the listener to remove
      */
     void removeCharacteristicsChangedListener(UUID characteristicsUUID, CharacteristicsChangedListener listener);
 
@@ -100,7 +100,6 @@ public interface Connection {
      * Gets the number of change listeners on the given characteristic.
      *
      * @param characteristicsUUID
-     *
      * @return the number of listeners or 0 is there are none
      */
     int getCharacteristicsChangedListenerCount(UUID characteristicsUUID);

--- a/neatle/src/main/java/si/inova/neatle/Device.java
+++ b/neatle/src/main/java/si/inova/neatle/Device.java
@@ -43,7 +43,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 class Device implements Connection {
 
-    private static final long DISCOVER_DEVICE_TIMEOUT = 30 * 1000;
+    private static final long DISCOVER_DEVICE_TIMEOUT = 60 * 1000;
 
     private final BluetoothDevice device;
     private final Handler handler;
@@ -303,17 +303,17 @@ class Device implements Connection {
         stopDiscovery();
 
         int state = getState();
-        if (device.getType() != BluetoothDevice.DEVICE_TYPE_UNKNOWN) {
-            if (state == BluetoothGatt.STATE_CONNECTING) {
-                NeatleLogger.e("Device discovered. Continuing with connecting");
-                connectWithGatt();
-            } else {
-                NeatleLogger.e("Device discovered but no longer connecting");
-            }
+//        if (device.getType() != BluetoothDevice.DEVICE_TYPE_UNKNOWN) {
+        if (state == BluetoothGatt.STATE_CONNECTING) {
+            NeatleLogger.i("Device discovered. Continuing with connecting");
+            connectWithGatt();
         } else {
-            NeatleLogger.e("Device discovered but is of unknown type.");
-            connectionFailed(BluetoothGatt.GATT_FAILURE);
+            NeatleLogger.e("Device discovered but no longer connecting");
         }
+//        } else {
+//            NeatleLogger.e("Device discovered but is of unknown type.");
+//            connectionFailed(BluetoothGatt.GATT_FAILURE);
+//        }
     }
 
     private void stopDiscovery() {

--- a/neatle/src/main/java/si/inova/neatle/DeviceManager.java
+++ b/neatle/src/main/java/si/inova/neatle/DeviceManager.java
@@ -48,6 +48,7 @@ class DeviceManager {
     }
 
     public synchronized Device getDevice(BluetoothDevice device) {
+        NeatleLogger.d("Getting connection object for " + device.getAddress());
         Device dev = devices.get(device.getAddress());
         if (dev == null) {
             dev = new Device(context, device);

--- a/neatle/src/main/java/si/inova/neatle/OperationImpl.java
+++ b/neatle/src/main/java/si/inova/neatle/OperationImpl.java
@@ -219,7 +219,7 @@ class OperationImpl implements Operation {
                 current = NO_COMMAND;
             }
 
-            NeatleLogger.d("Command finished, status: " + result.getStatus() + ", command:" + command);
+            NeatleLogger.d("Command finished, status: " + result.getStatus() + ", command:" + command + ", on: " + device.getAddress());
             handler.post(new Runnable() {
                 @Override
                 public void run() {
@@ -319,7 +319,7 @@ class OperationImpl implements Operation {
 
         @Override
         protected void execute(Connection connection, BluetoothGatt gatt, OperationResults results) {
-            throw new IllegalStateException("Should no be called");
+            throw new IllegalStateException("Should not be called");
         }
 
         @Override

--- a/neatle/src/main/java/si/inova/neatle/ReadCommand.java
+++ b/neatle/src/main/java/si/inova/neatle/ReadCommand.java
@@ -48,10 +48,17 @@ class ReadCommand extends Command {
         if (service != null) {
             BluetoothGattCharacteristic characteristic = service.getCharacteristic(characteristicUUID);
             if (characteristic != null) {
+                NeatleLogger.d("Reading characteristics " + characteristicUUID);
                 if (gatt.readCharacteristic(characteristic)) {
                     return;
                 }
+                NeatleLogger.d("Read failed" + characteristicUUID);
+            } else {
+                NeatleLogger.e("Could not find characteristics " + characteristicUUID);
             }
+
+        } else {
+            NeatleLogger.e("Could not find service " + serviceUUID);
         }
 
         finish(CommandResult.createErrorResult(characteristicUUID, BluetoothGatt.GATT_FAILURE));
@@ -67,7 +74,9 @@ class ReadCommand extends Command {
             NeatleLogger.e("Got a read request for a unknown characteristic");
             return;
         }
+
         CommandResult result = CommandResult.onCharacteristicRead(characteristic, status);
+        NeatleLogger.d("Read " + result);
         finish(result);
     }
 


### PR DESCRIPTION
Increased device discovery timeout from 30s to 60s.
The connection does not fail now when a device of an unknown type is discovered.
Added getValueAsInt32 to CommandResult.
Added some more logging.