### PR TITLE
Fix wrong comparation on CharacteristicSubscription

### DIFF
--- a/neatle/src/main/java/si/inova/neatle/operation/CharacteristicSubscriptionImpl.java
+++ b/neatle/src/main/java/si/inova/neatle/operation/CharacteristicSubscriptionImpl.java
@@ -88,7 +88,7 @@ public class CharacteristicSubscriptionImpl implements CharacteristicSubscriptio
 
     @Override
     public void start() {
-        if (!started) {
+        if (started) {
             return;
         }
 
@@ -109,7 +109,7 @@ public class CharacteristicSubscriptionImpl implements CharacteristicSubscriptio
 
     @Override
     public void stop() {
-        if (started) {
+        if (!started) {
             return;
         }
 


### PR DESCRIPTION
Fix bug on subscription.  The condition was inverted and was unable to subscribe to any characteristic. 