### PR TITLE
Fixes

### DIFF
--- a/neatle/build.gradle
+++ b/neatle/build.gradle
@@ -61,6 +61,8 @@ android {
                 includeNoLocationClasses = true
             }
         }
+
+        unitTests.returnDefaultValues = true
     }
 
     libraryVariants.all { variant ->

--- a/neatle/src/main/java/si/inova/neatle/Device.java
+++ b/neatle/src/main/java/si/inova/neatle/Device.java
@@ -36,6 +36,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.RequiresApi;
 import android.support.annotation.RestrictTo;
+import android.support.annotation.VisibleForTesting;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -420,7 +421,8 @@ public class Device implements Connection {
         }
     }
 
-    private void connectWithGatt() {
+    @VisibleForTesting
+    void connectWithGatt() {
         int oldState;
         int newState = BluetoothGatt.STATE_CONNECTING;
         synchronized (lock) {
@@ -432,6 +434,10 @@ public class Device implements Connection {
         BluetoothGatt gatt = device.connectGatt(context, false, callback);
 
         synchronized (lock) {
+            if (state == BluetoothGatt.STATE_DISCONNECTED) {
+                gatt = null;
+            }
+
             this.gatt = gatt;
             if (gatt == null) {
                 state = BluetoothGatt.STATE_DISCONNECTED;

--- a/neatle/src/main/java/si/inova/neatle/Device.java
+++ b/neatle/src/main/java/si/inova/neatle/Device.java
@@ -495,7 +495,7 @@ public class Device implements Connection {
         int newState;
         LinkedList<BluetoothGattCallback> queueCopy;
 
-
+        BluetoothGatt oldGatt;
         synchronized (lock) {
             oldState = state;
             state = BluetoothGatt.STATE_DISCONNECTED;
@@ -503,17 +503,17 @@ public class Device implements Connection {
             serviceDiscovered = false;
             current = currentCallback;
             queueCopy = new LinkedList<>(queue);
+
+            oldGatt = this.gatt;
+            this.gatt = null;
         }
 
         NeatleLogger.i("Connection attempt failed. Notifying all pending operations");
 
-        current.onConnectionStateChange(this.gatt, status, BluetoothGatt.STATE_DISCONNECTED);
+        current.onConnectionStateChange(oldGatt, status, BluetoothGatt.STATE_DISCONNECTED);
 
         for (BluetoothGattCallback cb : queueCopy) {
-            cb.onConnectionStateChange(gatt, status, BluetoothGatt.STATE_DISCONNECTED);
-        }
-        synchronized (lock) {
-            this.gatt = null;
+            cb.onConnectionStateChange(oldGatt, status, BluetoothGatt.STATE_DISCONNECTED);
         }
 
         notifyConnectionStateChange(oldState, newState);

--- a/neatle/src/main/java/si/inova/neatle/operation/WriteCommand.java
+++ b/neatle/src/main/java/si/inova/neatle/operation/WriteCommand.java
@@ -133,13 +133,18 @@ class WriteCommand extends SingleCharacteristicsCommand {
             } catch (IOException ex) {
                 NeatleLogger.e("Failed to get the first chunk", ex);
                 finish(CommandResult.createErrorResult(characteristicUUID, BluetoothGatt.GATT_FAILURE));
+                try {
+                    buffer.close();
+                } catch (IOException e) {
+                    NeatleLogger.e("Failed to close input source", e);
+                }
                 return;
             }
             if (chunk == null) {
                 try {
                     buffer.close();
                 } catch (IOException e) {
-                    // Closing, ignore exception
+                    NeatleLogger.e("Failed to close input source", e);
                 }
                 finish(CommandResult.createEmptySuccess(characteristicUUID));
                 return;

--- a/neatle/src/main/java/si/inova/neatle/operation/WriteCommand.java
+++ b/neatle/src/main/java/si/inova/neatle/operation/WriteCommand.java
@@ -187,7 +187,6 @@ class WriteCommand extends SingleCharacteristicsCommand {
                     });
 
                     if (chunk == null) {
-                        buffer.close();
                         return;
                     }
 
@@ -195,20 +194,22 @@ class WriteCommand extends SingleCharacteristicsCommand {
                         bufferReadLock.wait();
                     }
                 }
-            } catch (IOException | InterruptedException ex) {
+            } catch (InterruptedException ignored) {
+                // We got interrupted. Error was already handled elsewhere.
+            } catch (IOException ex) {
                 fail(ex);
+            } finally {
+                try {
+                    buffer.close();
+                } catch (IOException closeEx) {
+                    NeatleLogger.e("Failed to close input source", closeEx);
+                }
             }
         }
 
         private void fail(Exception ex) {
             NeatleLogger.e("Failed to read", ex);
-            try {
-              buffer.close();
-            } catch (IOException closeEx) {
-                NeatleLogger.e("Failed to close input source", closeEx);
-            } finally {
-                finish(CommandResult.createErrorResult(characteristicUUID, BluetoothGatt.GATT_FAILURE));
-            }
+            finish(CommandResult.createErrorResult(characteristicUUID, BluetoothGatt.GATT_FAILURE));
         }
     }
 }

--- a/neatle/src/test/java/si/inova/neatle/DeviceTest.java
+++ b/neatle/src/test/java/si/inova/neatle/DeviceTest.java
@@ -8,6 +8,7 @@ import android.content.Context;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -54,6 +55,63 @@ public class DeviceTest {
         device.connectWithGatt();
 
         // 2. Immediatelly try to connect again
+        device.connect();
+
+        // We should not get any exceptions
+    }
+
+    @Test
+    public void connectAfterConnectionFailed() throws Exception {
+        final ArgumentCaptor<BluetoothGattCallback> deviceCallback =
+                ArgumentCaptor.forClass(BluetoothGattCallback.class);
+
+        BluetoothGattCallback externalCallback = Mockito.mock(BluetoothGattCallback.class);
+        Mockito.when(btDevice.connectGatt(
+                Mockito.<Context>any(),
+                Mockito.anyBoolean(),
+                deviceCallback.capture())
+        ).thenReturn(Mockito.mock(BluetoothGatt.class));
+
+        Mockito.doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocationOnMock) {
+                try {
+                    //noinspection deprecation
+                    Thread.currentThread().stop();
+                } catch (Exception ignored) {
+                }
+
+                return null;
+            }
+        }).when(externalCallback).onConnectionStateChange(
+                Mockito.<BluetoothGatt>any(),
+                Mockito.eq(8000),
+                Mockito.eq(BluetoothGatt.STATE_DISCONNECTED)
+        );
+
+        // 1. Set external callback
+        device.execute(externalCallback);
+
+        // 2. Connect on background thread (simulate multithreaded BT stack on some devices)
+        // 2.1 This thread will get stuck in the middle of processing callbacks
+        // (to simulate later connect() being executed before connectionFailed() finishes)
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                device.connectWithGatt();
+                deviceCallback.getValue().onConnectionStateChange(
+                        Mockito.mock(BluetoothGatt.class),
+                        8000,
+                        BluetoothGatt.STATE_DISCONNECTED
+                );
+            }
+        };
+        thread.setDaemon(true);
+        thread.start();
+
+        Thread.sleep(50);
+
+        // 3. Immediatelly try to connect again
         device.connect();
 
         // We should not get any exceptions

--- a/neatle/src/test/java/si/inova/neatle/DeviceTest.java
+++ b/neatle/src/test/java/si/inova/neatle/DeviceTest.java
@@ -1,0 +1,61 @@
+package si.inova.neatle;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothGatt;
+import android.bluetooth.BluetoothGattCallback;
+import android.content.Context;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+public class DeviceTest {
+    @Mock
+    private Context context;
+
+    @Mock
+    private BluetoothDevice btDevice;
+
+    @Mock
+    private BluetoothAdapter adapter;
+
+    private Device device;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        device = new Device(context, btDevice, adapter);
+    }
+
+    @Test
+    public void connectAfterConnectWithGattFailWhileConnecting() {
+        Mockito.when(btDevice.connectGatt(
+                Mockito.<Context>any(),
+                Mockito.anyBoolean(),
+                Mockito.<BluetoothGattCallback>any())
+        ).thenAnswer(new Answer<BluetoothGatt>() {
+            @Override
+            public BluetoothGatt answer(InvocationOnMock invocationOnMock) {
+                BluetoothGatt gatt = Mockito.mock(BluetoothGatt.class);
+                BluetoothGattCallback callback = invocationOnMock.getArgument(2);
+                callback.onConnectionStateChange(gatt, 0, BluetoothGatt.STATE_DISCONNECTED);
+                return gatt;
+            }
+        });
+
+        // 1. Connect with gatt
+        // 1.1 While connecting, gatt will throw disconnect error
+        device.connectWithGatt();
+
+        // 2. Immediatelly try to connect again
+        device.connect();
+
+        // We should not get any exceptions
+    }
+}

--- a/neatle/src/test/java/si/inova/neatle/DeviceTest.java
+++ b/neatle/src/test/java/si/inova/neatle/DeviceTest.java
@@ -6,6 +6,7 @@ import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCallback;
 import android.content.Context;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -57,7 +58,8 @@ public class DeviceTest {
         // 2. Immediatelly try to connect again
         device.connect();
 
-        // We should not get any exceptions
+        // This test checks for the exception. If we got so far, test passed
+        Assert.assertTrue(true);
     }
 
     @Test
@@ -114,6 +116,7 @@ public class DeviceTest {
         // 3. Immediatelly try to connect again
         device.connect();
 
-        // We should not get any exceptions
+        // This test checks for the exception. If we got so far, test passed
+        Assert.assertTrue(true);
     }
 }

--- a/neatle/src/test/java/si/inova/neatle/operation/WriteCommandTest.java
+++ b/neatle/src/test/java/si/inova/neatle/operation/WriteCommandTest.java
@@ -35,6 +35,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -363,6 +365,40 @@ public class WriteCommandTest {
         writeCommand.onError(BluetoothGatt.GATT_FAILURE);
         verifyCommandFail();
     }
+    @Test
+    public void testAsyncOnError() throws Exception {
+        when(gatt.getService(eq(serviceUUID))).thenReturn(gattService);
+        when(gattService.getCharacteristic(characteristicUUID)).thenReturn(gattCharacteristic);
+        when(gatt.writeCharacteristic(eq(gattCharacteristic))).thenReturn(true);
+
+        AsyncInputSource inputSource = Mockito.mock(AsyncInputSource.class);
+        when(inputSource.nextChunk()).thenAnswer(new Answer<byte[]>()
+        {
+            @Override
+            public byte[] answer(InvocationOnMock invocationOnMock) {
+                writeCommand.onError(BluetoothGatt.GATT_FAILURE);
+                return new byte[]{12, 21};
+            }
+        });
+
+        writeCommand = new WriteCommand(
+                serviceUUID,
+                characteristicUUID,
+                BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT,
+                inputSource,
+                commandObserver);
+
+        writeCommand.execute(device, operationCommandObserver, gatt);
+
+        while (writeCommand.readerThread.isAlive()) {
+            Robolectric.getForegroundThreadScheduler().advanceBy(0, TimeUnit.MILLISECONDS);
+            Thread.yield();
+        }
+        Robolectric.getForegroundThreadScheduler().advanceBy(0, TimeUnit.MILLISECONDS);
+
+        verifyCommandFail();
+        verify(inputSource).close();
+    }
 
     @Test
     public void testToStringBecauseWhyNot() {
@@ -371,7 +407,7 @@ public class WriteCommandTest {
 
     private void verifyCommandFail() {
         CommandResult result = CommandResult.createErrorResult(characteristicUUID, BluetoothGatt.GATT_FAILURE);
-        verify(commandObserver, times(1)).finished(eq(writeCommand), refEq(result, "timestamp"));
-        verify(operationCommandObserver, times(1)).finished(eq(writeCommand), refEq(result, "timestamp"));
+        verify(commandObserver, only()).finished(eq(writeCommand), refEq(result, "timestamp"));
+        verify(operationCommandObserver, only()).finished(eq(writeCommand), refEq(result, "timestamp"));
     }
 }


### PR DESCRIPTION
* Fixed several Threading-related `IllegalStateException` crashes when using `Connection.connect()` method
* Fixed `InputSource.close()` not being called in some situations
* Fixed `CommandObserver` receiving two error resuls when `AsyncInputSource` is used and BT connection errors out.